### PR TITLE
fix minor typo

### DIFF
--- a/api-provider/task-api.json
+++ b/api-provider/task-api.json
@@ -29,7 +29,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The newly create task",
+            "description": "The newly created task",
             "schema": {
               "$ref": "#/definitions/Todo"
             }


### PR DESCRIPTION
Please review this minor typo fix. Change the response message for the post operator from "The newly create task" to "The newly created task"